### PR TITLE
fix: check `self.stdout` instead of `self.stderr` (#60)

### DIFF
--- a/flux/core/helpers/commands.py
+++ b/flux/core/helpers/commands.py
@@ -451,7 +451,7 @@ class CommandInterface(_ABC):
         """
         returns true if the stdout has been redirected
         """
-        return not (self.stderr and self.stdout == _sys.stdout)
+        return not (self.stdout and self.stdout == _sys.stdout)
 
     @property
     def redirected_stderr(self):


### PR DESCRIPTION
Fixes #60 